### PR TITLE
MDS-97 기저질환 알림 다이얼로그 API 오류 수정

### DIFF
--- a/medisight/lib/page/search_result.dart
+++ b/medisight/lib/page/search_result.dart
@@ -34,7 +34,7 @@ class _SearchResultPageState extends State<SearchResultPage> {
 
   void checkDisease() async {
     final response = await http.get(Uri.parse(
-        "http://192.168.123.102:5001/search/precautions/${widget.code}"));
+        "http://34.64.96.217:5001/search/precautions/${widget.code}"));
     final user = FirebaseAuth.instance.currentUser!;
     CollectionReference userProduct =
         FirebaseFirestore.instance.collection("user");


### PR DESCRIPTION
- 기저질환이 검색되어도 팝업이 뜨지 않던 오류 해결
- 배포 서버의 엔드포인트로 수정