### PR TITLE
MDS-114 내비게이션 플로팅 버튼 오류 해결

### DIFF
--- a/medisight/lib/screen/bottom_navi.dart
+++ b/medisight/lib/screen/bottom_navi.dart
@@ -64,6 +64,7 @@ class BottomNaviState extends State<BottomNavi> {
             .maybePop());
       },
       child: Scaffold(
+        resizeToAvoidBottomInset: false,
         floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
         bottomNavigationBar: BottomAppBar(
           child: Container(


### PR DESCRIPTION
- 내비게이션의 카메라 플로팅 버튼이 위로 올라가는 오류 해결