### PR TITLE
MDS-122 [!HOTFIX] 백엔드 에러 핸들링 및 버그 패치

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medisight-be",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medisight-be",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.9.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "node-schedule": "^2.1.1",
-        "nodemon": "^2.0.20",
+        "nodemon": "^2.0.22",
         "prisma": "^4.9.0",
         "request": "^2.88.2",
         "xml-js": "^1.6.11"
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
+      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "node-schedule": "^2.1.1",
-    "nodemon": "^2.0.20",
+    "nodemon": "^2.0.22",
     "prisma": "^4.9.0",
     "request": "^2.88.2",
     "xml-js": "^1.6.11"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medisight-be",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/backend/prisma/migrations/20230406023120_init/migration.sql
+++ b/backend/prisma/migrations/20230406023120_init/migration.sql
@@ -65,7 +65,7 @@ CREATE TABLE `Permission` (
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
-CREATE TABLE `household` (
+CREATE TABLE `Household` (
     `id` BIGINT NOT NULL AUTO_INCREMENT,
     `prdlstNm` VARCHAR(300) NULL,
     `bsshNm` VARCHAR(300) NULL,

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -70,7 +70,7 @@ model Permission {
   mainIngrEng      String? @db.Text
 }
 
-model household {
+model Household {
   id          BigInt  @id @default(autoincrement())
   prdlstNm    String? @db.VarChar(300)
   bsshNm      String? @db.VarChar(300)

--- a/backend/routes/Map.js
+++ b/backend/routes/Map.js
@@ -15,10 +15,20 @@ router.get('/place', async (req, res) => {
         url: endpoint
     },
     function(error, response, body){
-        const json = JSON.parse(body)
-        const result = cleanse_place(json.searchPoiInfo.pois.poi)
-        //console.log(result);
-        res.send({result});
+        if (error) {
+            console.log(error);
+            res.status(502).send({"error": 'Could not get response from external api'});
+            return;
+        }
+        try {
+            const json = JSON.parse(body)
+            const result = cleanse_place(json.searchPoiInfo.pois.poi)
+            //console.log(result);
+            res.send({result});
+        } catch (err) {
+            res.status(500).send({"error": 'Fail to parse POI info'});
+            console.log(err);
+        }
     });
 });
 
@@ -60,7 +70,7 @@ router.post('/route', async (req, res) => {
         "searchOption": "0",
         "resCoordType": "WGS84GEO",
         "sort": "index"
-      }
+    }
 
     request.post({
         headers: {'Accept' : 'application/json', 'appKey' : apiKey},
@@ -68,10 +78,20 @@ router.post('/route', async (req, res) => {
         body: JSON.stringify(payload)
     },
     function(error, response, body){
-        const json = JSON.parse(body)
-        const result = cleanse_route(json.features)
-        //console.log(result);
-        res.send(result);
+        if (error) {
+            console.log(error);
+            res.status(502).send({"error": 'Could not get response from external api'});
+            return;
+        }
+        try {
+            const json = JSON.parse(body)
+            const result = cleanse_route(json.features)
+            //console.log(result);
+            res.send(result);
+        } catch (err) {
+            res.status(500).send({"error": 'Fail to parse features'});
+            console.log(err);
+        }
     });
 });
 
@@ -138,12 +158,22 @@ router.post('/route/coords', async (req, res) => {
         body: JSON.stringify(payload)
     },
     function(error, response, body){
-        const json = JSON.parse(body)
-        const result = {}
-        result.points = get_route_points(json.features)
-        result.linestrings = get_route_lines(json.features)
-        //console.log(result);
-        res.send(result);
+        if (error) {
+            console.log(error);
+            res.status(502).send({"error": 'Could not get response from external api'});
+            return;
+        }
+        try {
+            const json = JSON.parse(body)
+            const result = {}
+            result.points = get_route_points(json.features)
+            result.linestrings = get_route_lines(json.features)
+            //console.log(result);
+            res.send(result);
+        } catch (err) {
+            res.status(500).send({"error": 'Fail to parse features'});
+            console.log(err);
+        }
     });
 });
 

--- a/backend/util/Database.js
+++ b/backend/util/Database.js
@@ -7,12 +7,16 @@ const { grainDB, permissionDB, householdDB } = require('../util/OpenAPI');
 
 // 매일 새벽 3시마다 실행
 const schedule = scheduler.scheduleJob("0 00 3 * * *", async function () {
-    // 저장된 데이터 전체 삭제
-    await prisma.$queryRaw`TRUNCATE TABLE grain;`
-    await prisma.$queryRaw`TRUNCATE TABLE permission;`
-    await prisma.$queryRaw`TRUNCATE TABLE household;`
+    try {
+        // 저장된 데이터 전체 삭제
+        await prisma.$queryRaw`TRUNCATE TABLE grain;`
+        await prisma.$queryRaw`TRUNCATE TABLE permission;`
+        await prisma.$queryRaw`TRUNCATE TABLE household;`
 
-    grainDB();
-    permissionDB();
-    householdDB();
+        grainDB();
+        permissionDB();
+        householdDB();
+    } catch(err) {
+        console.log(err);
+    }
 });


### PR DESCRIPTION
- 지도 API에서 Tmap 호출에 실패하거나 파싱에러가 발생할 경우의 에러 핸들링 추가
- 공공데이터 DB 대소문자 고정 (OS별로 대소문자가 구분되기도 하므로 테이블명은 반드시 대문자로 할 것)
    - Prisma schema 및 migration SQL 수정
- 백엔드 버전 업데이트: `1.0.0` -> `1.1.0`

### 참고
- hotfix이므로 바로 main에 머지됨
- GCP Cloud SQL에 새 schema 반영 완료